### PR TITLE
Add back git for the git hash keygen plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update -y \
     && apt-get install -yq \
     ca-certificates \
     fonts-liberation \
+    git \
     libappindicator3-1 \
     libasound2 \
     libatk-bridge2.0-0 \


### PR DESCRIPTION
Since the latest release the git keygen plugin has been failing because git isn't found in the container